### PR TITLE
Handle service / interface restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ class { 'network_config': }
 | `exclude_if`      | List of interfaces to exclude from management, even if `interfaces` has them | lo |
 | `networkmanager`  | True or false, is NetworkManager enabled (to be deprecated) | RHEL7 true, RHEL6 false |
 | `restart_service`* | Whether or not to restart the network service on change | true |
-| `restart_interface`* | Whether or not to restart the affected network interface on change | true |
+| `restart_interface`* | Whether or not to restart the affected network interface on change | false |
 
  _* only one of restart_interface or restart_service can be defined_
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ class { 'network_config': }
 | `bonds`           | [Bond interfaces and specific configuration](#bonding) | {} |
 | `exclude_if`      | List of interfaces to exclude from management, even if `interfaces` has them | lo |
 | `networkmanager`  | True or false, is NetworkManager enabled (to be deprecated) | RHEL7 true, RHEL6 false |
-| `restart_service` | Whether or not to restart the network service on change | true |
+| `restart_service`* | Whether or not to restart the network service on change | true |
+| `restart_interface`* | Whether or not to restart the affected network interface on change | true |
+
+ _* only one of restart_interface or restart_service can be defined_
+
 
 ### Configuration using hiera
 

--- a/manifests/ifconfig.pp
+++ b/manifests/ifconfig.pp
@@ -54,7 +54,6 @@ define network_config::ifconfig (
       prefix    => $prefix,
       gateway   => $gateway,
       interface => $interface_name,
-      notify    => 
     }
     ip_allocation { $ip_allocations: }
   }

--- a/manifests/ifconfig.pp
+++ b/manifests/ifconfig.pp
@@ -54,6 +54,7 @@ define network_config::ifconfig (
       prefix    => $prefix,
       gateway   => $gateway,
       interface => $interface_name,
+      notify    => 
     }
     ip_allocation { $ip_allocations: }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,11 +126,21 @@ class network_config (
   $exclude_if = 'lo',
   $networkmanager = $::network_config::params::networkmanager,
   $restart_service = true,
+  $restart_interface = false,
   $bonds = {}
 ) inherits network_config::params {
 
   # In this base class we pull in the data from hiera, which
   # will get referenced here from the interface definition below.
+
+  if $restart_interface and $restart_service {
+    fail('Only one of restart_interface or restart_service can be enabled')
+  }
+
+  service { 'network':
+    ensure => running,
+  }
+
 
   # Create an array of configured interfaces, minus any to be excluded
   # and then for each interface we declare a network_config::interface

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -21,7 +21,7 @@ define network_config::interface  (
     fail('network_config base class must be included before network_config::interface')
   }
 
-  # Declare a service for this interface.  This enabled individual
+  # Declare a service for this interface.  This enables individual
   # interfaces to be restarted upon change, rather than the whole
   # network service.
   #
@@ -89,10 +89,21 @@ define network_config::interface  (
     }
   }
 
+  # Set the correct service to restart
+  if $::network_config::restart_service {
+    $notify_resource = { 'notify' => Service['network'] }
+  } elsif $::network_config::restart_interface {
+    $notify_resource = { 'notify' => Service["ifconfig-${name}"] }
+  } else {
+    $notify_resource = {}
+  }
+
+
   # Here we take all of the various configurations and merge them in the 
   # right order (right wins).  Starting with interface defaults and finally
   # ifconfig params.
-  $params_merged = merge( $int_defaults,
+  $params_merged = merge( $notify_resource,
+                          $int_defaults,
                           $bond_overrides,
                           $slave_config,
                           $vlan_overrides,


### PR DESCRIPTION

This supersedes #4 and adds `restart_interface` attribute so the module only restarts the affected interface if set.