### PR TITLE
Quote hash key for $resource.

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -111,7 +111,7 @@ define network_config::interface  (
 
 
   # Build the resource hash, consisting of the interface id and parameters
-  $resource = { $title => $params_merged }
+  $resource = { "${title}" => $params_merged }
 
 
   # Pass the resource and defaults hash to create_resources to declare


### PR DESCRIPTION
Puppet 3.x can't seem to handle non quoted hash keys even if they are
variables.