### PR TITLE
Bugfix: GATEWAY= added to interface when ip allocations are set

### DIFF
--- a/manifests/ifconfig.pp
+++ b/manifests/ifconfig.pp
@@ -54,8 +54,10 @@ define network_config::ifconfig (
   if $ipaddr {
     if $networkmanager {
       $ip_allocations = any2array($ipaddr)
+      $int_gateway = undef
     } else {
       $ip_allocations = $ipaddr
+      $int_gateway = $gateway
     }
     Ip_allocation {
       ensure    => present,
@@ -64,6 +66,8 @@ define network_config::ifconfig (
       interface => $interface_name,
     }
     ip_allocation { $ip_allocations: }
+  } else {
+    $int_gateway = $gateway
   }
 
   network_interface { $title:
@@ -92,7 +96,7 @@ define network_config::ifconfig (
     master             => $master,
     slave              => $slave,
     peerdns            => $peerdns,
-    gateway            => $gateway,
+    gateway            => $int_gateway,
   }
 
 


### PR DESCRIPTION
This is a hangover from #20  and #21 

This change means that `GATEWAY=` gets added to interfaces even when there are IP allocations that set `GATEWAY0,1,2...etc` - this PR only adds `GATEWAY=` for non NM controlled systems