### PR TITLE
Route default gateway

### DIFF
--- a/manifests/ifconfig.pp
+++ b/manifests/ifconfig.pp
@@ -48,7 +48,11 @@ define network_config::ifconfig (
 
 
   if $routes {
-    create_resources("ip_route", $routes, { "interface" => $interface_name })
+    $route_defaults = {
+      'interface' => $interface_name,
+      'gateway'   => $gateway,
+    }
+    create_resources('ip_route', $routes, $route_defaults)
     Network_interface <||> -> Ip_route <||>
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -60,6 +60,11 @@ describe 'network_config' do
         :gateway => '10.1.1.1',
         :interface => 'ens99'
       )
+      is_expected.to contain_ip_route('10.1.2.0/24').with(
+        :netmask => '255.255.255.0',
+        :gateway => '10.7.6.3',
+        :interface => 'ens39'
+      )
     }
   end
 

--- a/spec/fixtures/data/common.yaml
+++ b/spec/fixtures/data/common.yaml
@@ -87,6 +87,8 @@ network_config::ifconfig:
   backup:
     ipaddr: 10.7.6.10
     vlan: 100
+    routes:
+      10.1.2.0/24: {}
   management:
     ipaddr: 10.1.1.1
     vlan: 300

--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -5,5 +5,5 @@
 :yaml:
   :datadir: ./spec/fixtures/data
 
-:hierararchy:
+:hierarchy:
   - common


### PR DESCRIPTION
The routes specified for an interface should use the default gateway of the vlan.