### PR TITLE
ensure values with spaces are quoted

### DIFF
--- a/lib/puppet/provider/network_interface/default.rb
+++ b/lib/puppet/provider/network_interface/default.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:network_interface).provide(:default, :parent => Puppet::Provi
   ]
 
   FIELDS = FIELDS_LC
-    
+
   mk_resource_methods
 
   FIELDS.each do |f|
@@ -59,7 +59,7 @@ Puppet::Type.type(:network_interface).provide(:default, :parent => Puppet::Provi
   def exists?
     @property_hash[:ensure] == :present
   end
-   
+
   def create
     @property_flush[:ensure] = :present
     FIELDS.each do |f|
@@ -101,13 +101,14 @@ Puppet::Type.type(:network_interface).provide(:default, :parent => Puppet::Provi
     instances = []
     ifcfg_files.each do |file|
       data = load_file_data(file)
-      attrs = { 
+      attrs = {
         :target => file,
-        :ensure => :present, 
+        :ensure => :present,
       }
       FIELDS.each do |field|
         if val = data.get_value('',field)
-          attrs[setting_to_param(field)]=val.gsub(/\"/,'')
+          val = val.gsub(/\"/,'') unless val.include?(' ')
+          attrs[setting_to_param(field)]=val
         end
       end
 

--- a/lib/puppet/type/network_interface.rb
+++ b/lib/puppet/type/network_interface.rb
@@ -9,9 +9,19 @@ Puppet::Type.newtype(:network_interface) do
 
   newparam(:target)
 
-  newproperty(:netmask )
-  newproperty(:bootproto )
-  newproperty(:defroute )
+  ensure_quoted = Proc.new do
+    munge do |value|
+      if value.include?(' ') && !value.match(/\A\".*\"\z/)
+        "\"#{value}\""
+      else
+        value
+      end
+    end
+  end
+
+  newproperty(:netmask)
+  newproperty(:bootproto)
+  newproperty(:defroute)
   newproperty(:ipv4_failure_fatal)
   newproperty(:ipv6init)
   newproperty(:ipv6_autoconf)
@@ -22,18 +32,18 @@ Puppet::Type.newtype(:network_interface) do
   newproperty(:dns1)
   newproperty(:dns2)
   newproperty(:dns3)
-  newproperty(:domain)
+  newproperty(:domain, &ensure_quoted)
   newproperty(:hwaddr)
   newproperty(:ipv6_peerdns)
   newproperty(:ipv6_peerroutes)
   newproperty(:zone)
   newproperty(:type)
   newproperty(:device)
-  newproperty(:bonding_opts)
+  newproperty(:bonding_opts, &ensure_quoted)
   newproperty(:bonding_master)
   newproperty(:master)
   newproperty(:slave)
-  newproperty(:netboot )
+  newproperty(:netboot)
   newproperty(:nm_controlled)
   newproperty(:peerdns)
   newproperty(:gateway)


### PR DESCRIPTION
Options like bounding_opts or domain can have multiple parameters or values separated by spaces. If those strings are not quoted then only the first part is used.

This will add a munge block to those options to ensure the value is quoted if it contains spaces. It will also keep the quotes in the value read from the disk if it contains spaces in order for this to work.

Since changing things like this will restart the network interfaces if configured like this I tried to keep the impact as small as possible so it only changes values where absolutely necessary.