### PR TITLE
ignore .old files created by firewalld

### DIFF
--- a/lib/puppet/provider/network_config.rb
+++ b/lib/puppet/provider/network_config.rb
@@ -29,7 +29,7 @@ class Puppet::Provider::Network_config < Puppet::Provider
 
   def self.ifcfg_files
     files = Dir.glob(File.join(CONF_DIR, "ifcfg-*"))
-    files.reject{|file| file.end_with?('.bak')}
+    files.reject{|file| file.end_with?('.bak', '.old')}
   end
 
   def self.conf_dir


### PR DESCRIPTION
Similar to the .bak file, firewalld creates a .old file and the provider then reads the state for the interface from there instead of the original. This leads to changes and hence interface reloads on every run.